### PR TITLE
Install cmx file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endif
 install:
 	rm -rf $(DESTDIR)/ancient
 	install -c -m 0755 -d $(DESTDIR)/ancient
-	install -c -m 0644 *.cmi *.mli *.cma *.cmxa *.a mmalloc/*.a META \
+	install -c -m 0644 *.cmi *.mli *.cma *.cmx *.cmxa *.a mmalloc/*.a META \
 	  $(DESTDIR)/ancient
 
 # Distribution.


### PR DESCRIPTION
Linking Ancient library with Dune outputs the warning: 
```
File "_none_", line 1:
Warning 58 [no-cmx-file]: no cmx file was found in path for module Ancient, and its interface was not compiled with -opaque
```
This PR changes the Makefile to install the cmx file.