### PR TITLE
Add licenses in opam files

### DIFF
--- a/ancient-community.opam
+++ b/ancient-community.opam
@@ -34,6 +34,9 @@ processes.  In this mode, the structures are backed by a disk file,
 and any process that has read/write access that disk file can map that
 file in and see the structures.
 """
+license: [
+  "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
 # url {
 #   src: "https://github.com/UnixJunkie/ocaml-ancient/archive/XXX.tar.gz"
 #   checksum: "md5=YYY"

--- a/ancient.opam
+++ b/ancient.opam
@@ -37,3 +37,6 @@ processes.  In this mode, the structures are backed by a disk file,
 and any process that has read/write access that disk file can map that
 file in and see the structures.
 """
+license: [
+  "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]


### PR DESCRIPTION
Remove the warning: 
```
warning 68: Missing field 'license'
```